### PR TITLE
Normalize file paths so that tests can pass across different platforms.

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ module.exports = exports = function mockGulpDest (gulpOrVinylFs) {
       var files = filesFromTree(filePath);
       files.forEach(function (filePath) {
         assert.ok(cache.some(function (file) {
-          return file.relative === filePath;
+          return file.relative === path.normalize(filePath);
         }), 'Expected `' + info.base + '` to contain `' + filePath + '`');
       });
     },
@@ -59,7 +59,7 @@ module.exports = exports = function mockGulpDest (gulpOrVinylFs) {
       var files = filesFromTree(filePath);
       files.forEach(function (filePath) {
         assert.ok(cache.every(function (file) {
-          return file.relative !== filePath;
+          return file.relative !== path.normalize(filePath);
         }), 'Expected `' + info.base + '` to not contain `' + filePath + '`');
       });
     }


### PR DESCRIPTION
Currently, tests will fail on Windows if a forward slash is in the path if the path is a string. Likewise, if the file tree is passed in, the tests fail on Windows because the path is joined with a forward slash.

This patch normalizes the path in the assertion to make it work cross-platform.
